### PR TITLE
Allow to define custom accessor for registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.1 2020-09-23
+
+- Allow to define custom accessors for registries
+
 # v0.3.0 2020-09-10
 
 ### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_registry (0.3.0)
+    nxt_registry (0.3.1)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ registry.resolve(:aki) # => 'Aki'
 
 ## Class Level
 
-You can register registries on the class level simply by extending your class with `NxtRegistry`
+You can add registries on the class level simply by extending your class with `NxtRegistry`
 
 ```ruby
 class OtherExample
@@ -161,7 +161,6 @@ end
 Layer.registry(:path).from(:munich).to(:amsterdam).via(:train, -> { 'train' })
 # Resolve the complete path
 Layer.registry(:path).from(:munich).to(:amsterdam).via(:train) #  => 'train'
-
 ```
 
 *Note that this feature is also available for registries with a single level only.*

--- a/README.md
+++ b/README.md
@@ -130,16 +130,41 @@ class Layer
   end
 end
 
+# On every upper level every resolve returns a registry 
 Layer.registry(:from) # => Registry[from]
-
 Layer.registry(:from).resolve(:munich) # => Registry[to] -> {}
 Layer.registry(:from).resolve(:amsterdam) # => Registry[to] -> {}
 Layer.registry(:from).resolve(:any_key) # => Registry[to] -> {}
-
 Layer.registry(:from).resolve(:munich, :amsterdam) # => Registry[via] -> {}
+
+# Register a value on the bottom level
 Layer.registry(:from).resolve(:munich, :amsterdam).register(:train, -> { 'train' })
+# Resolve the complete path 
 Layer.registry(:from).resolve(:munich, :amsterdam, :train) #  => 'train'
 ``` 
+
+For registries with multiple levels the normal syntax for registering and resolving becomes quote weird and unreadable. This is why
+every registry can be accessed through it's name or a custom accessor. The above example then can be simplified as follows.
+
+```ruby
+class Layer
+  extend NxtRegistry
+  
+  registry :path, accessor: :from do # registry named path, can be accessed with .from(...)
+    level :to do
+      level :via
+    end  
+  end
+end
+
+# Register a value
+Layer.registry(:path).from(:munich).to(:amsterdam).via(:train, -> { 'train' })
+# Resolve the complete path
+Layer.registry(:path).from(:munich).to(:amsterdam).via(:train) #  => 'train'
+
+```
+
+*Note that this feature is also available for registries with a single level only.*
 
 ### Restrict attributes to a certain set
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Layer.registry(:from).resolve(:munich, :amsterdam).register(:train, -> { 'train'
 Layer.registry(:from).resolve(:munich, :amsterdam, :train) #  => 'train'
 ``` 
 
-For registries with multiple levels the normal syntax for registering and resolving becomes quote weird and unreadable. This is why
+For registries with multiple levels the normal syntax for registering and resolving becomes quite weird and unreadable. This is why
 every registry can be accessed through it's name or a custom accessor. The above example then can be simplified as follows.
 
 ```ruby

--- a/lib/nxt_registry.rb
+++ b/lib/nxt_registry.rb
@@ -1,30 +1,30 @@
 require 'active_support/core_ext'
-require "nxt_registry/version"
-require "nxt_registry/blank"
-require "nxt_registry/attribute"
-require "nxt_registry/errors"
-require "nxt_registry/registry_builder"
-require "nxt_registry/registry"
-require "nxt_registry/recursive_registry"
+require 'nxt_registry/version'
+require 'nxt_registry/blank'
+require 'nxt_registry/attribute'
+require 'nxt_registry/errors'
+require 'nxt_registry/registry_builder'
+require 'nxt_registry/registry'
+require 'nxt_registry/recursive_registry'
 
 module NxtRegistry
   def registry(name, **options, &config)
-    return registries.fetch(name) if registries.key?(name)
-
-    registry = Registry.new(name, **options, &config)
-    registries[name] ||= registry
-    registry
+    build_registry(Registry, name, **options, &config)
   end
 
   def recursive_registry(name, **options, &config)
-    return registries.fetch(name) if registries.key?(name)
-
-    registry = RecursiveRegistry.new(name, **options, &config)
-    registries[name] ||= registry
-    registry
+    build_registry(RecursiveRegistry, name, **options, &config)
   end
 
   private
+
+  def build_registry(registry_class, name, **options, &config)
+    return registries.fetch(name) if registries.key?(name)
+
+    registry = registry_class.new(name, **options, &config)
+    registries[name] ||= registry
+    registry
+  end
 
   def registries
     @registries ||= {}

--- a/lib/nxt_registry.rb
+++ b/lib/nxt_registry.rb
@@ -19,11 +19,22 @@ module NxtRegistry
   private
 
   def build_registry(registry_class, name, **options, &config)
-    return registries.fetch(name) if registries.key?(name)
+    if registries.key?(name)
+      registry = registries.fetch(name)
+      if registry.configured
+        registry
+      else
+        raise_unconfigured_registry_accessed(name)
+      end
+    else
+      registry = registry_class.new(name, **options, &config)
+      registries[name] ||= registry
+      registry
+    end
+  end
 
-    registry = registry_class.new(name, **options, &config)
-    registries[name] ||= registry
-    registry
+  def raise_unconfigured_registry_accessed(name)
+    raise ArgumentError, "The registry #{name} must be configured before accessed!"
   end
 
   def registries

--- a/lib/nxt_registry/registry.rb
+++ b/lib/nxt_registry/registry.rb
@@ -11,7 +11,7 @@ module NxtRegistry
       @attrs = nil
 
       setup_defaults(options)
-      configure(&config)
+      configure(&config) if block_given? || parent
     end
 
     attr_reader :name
@@ -205,6 +205,10 @@ module NxtRegistry
     end
 
     def define_interface
+      raise_invalid_accessor_name(accessor) if respond_to?(accessor)
+      accessor_with_bang = "#{accessor}!"
+      raise_invalid_accessor_name(accessor_with_bang) if respond_to?(accessor_with_bang)
+
       define_singleton_method accessor do |key = Blank.new, value = Blank.new|
         return self if is_a_blank?(key)
 
@@ -217,7 +221,7 @@ module NxtRegistry
         end
       end
 
-      define_singleton_method "#{accessor}!" do |key = Blank.new, value = Blank.new|
+      define_singleton_method accessor_with_bang do |key = Blank.new, value = Blank.new|
         return self if is_a_blank?(key)
 
         key = transformed_key(key)
@@ -309,6 +313,10 @@ module NxtRegistry
 
     def is_a_blank?(value)
       value.is_a?(Blank)
+    end
+
+    def raise_invalid_accessor_name(name)
+      raise ArgumentError, "#{self} already implements a method named: #{name}. Please choose a different accessor name"
     end
   end
 end

--- a/lib/nxt_registry/registry.rb
+++ b/lib/nxt_registry/registry.rb
@@ -9,12 +9,14 @@ module NxtRegistry
       @config = config
       @store = {}
       @attrs = nil
+      @configured = false
 
       setup_defaults(options)
       configure(&config) if block_given? || parent
     end
 
     attr_reader :name
+    attr_accessor :configured
 
     def level(name, **options, &config)
       options = options.merge(parent: self)
@@ -141,6 +143,8 @@ module NxtRegistry
           instance_exec(&block)
         end
       end
+
+      self.configured = true
     end
 
     def to_s

--- a/lib/nxt_registry/registry.rb
+++ b/lib/nxt_registry/registry.rb
@@ -3,6 +3,7 @@ module NxtRegistry
     def initialize(name = object_id.to_s, **options, &config)
       @name = name
       @parent = options[:parent]
+      @accessor = options.fetch(:accessor) { name }
       @is_leaf = true
       @namespace = build_namespace
       @config = config
@@ -151,7 +152,7 @@ module NxtRegistry
 
     private
 
-    attr_reader :namespace, :parent, :config, :store, :options
+    attr_reader :namespace, :parent, :config, :store, :options, :accessor
     attr_accessor :is_leaf
 
     def is_leaf?
@@ -205,7 +206,7 @@ module NxtRegistry
     end
 
     def define_interface
-      define_singleton_method name do |key = Blank.new, value = Blank.new|
+      define_singleton_method accessor do |key = Blank.new, value = Blank.new|
         return self if key.is_a?(Blank)
 
         key = transformed_key(key)
@@ -217,7 +218,7 @@ module NxtRegistry
         end
       end
 
-      define_singleton_method "#{name}!" do |key = Blank.new, value = Blank.new|
+      define_singleton_method "#{accessor}!" do |key = Blank.new, value = Blank.new|
         return self if key.is_a?(Blank)
 
         key = transformed_key(key)

--- a/lib/nxt_registry/version.rb
+++ b/lib/nxt_registry/version.rb
@@ -1,3 +1,3 @@
 module NxtRegistry
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/nxt_registry.gemspec
+++ b/nxt_registry.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = "nxt_registry"
   spec.version       = NxtRegistry::VERSION
   spec.authors       = ["Andreas Robecke", "Nils Sommer", "Raphael Kallensee", "Lütfi Demirci"]
-  spec.email         = ["a.robecke@getsafe.de"]
+  spec.email         = ['a.robecke@hellogetsafe.com', 'andreas@robecke.de']
 
   spec.summary       = %q{nxt_registry is a simple implementation of the container pattern}
   spec.homepage      = "https://github.com/nxt-insurance"

--- a/spec/nxt_registry_spec.rb
+++ b/spec/nxt_registry_spec.rb
@@ -286,6 +286,25 @@ RSpec.describe NxtRegistry do
     end
   end
 
+  describe 'accessor option' do
+    subject do
+      NxtRegistry::Registry.new(:path, accessor: :from)
+    end
+
+    it 'defines custom accessors' do
+      subject.configure do
+        level :to do
+          level :via do
+            resolver ->(value) { "The passenger travels via: #{value}" }
+          end
+        end
+      end
+
+      subject.from(:a).to(:b).via(:train, 'ICE')
+      expect(subject.from(:a).to(:b).via(:train)).to eq('The passenger travels via: ICE')
+    end
+  end
+
   describe '#on_key_already_registered' do
     subject do
       NxtRegistry::Registry.new(:test) do

--- a/spec/nxt_registry_spec.rb
+++ b/spec/nxt_registry_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe NxtRegistry do
       subject { test_class.new }
 
       it do
-        expect(subject.registry(:developers)).to eq(subject.devs)
+        expect(subject.devs).to eq(subject.registry(:developers))
       end
     end
   end


### PR DESCRIPTION
Explain accessors in README and allow to define custom accessors for registries so that accessor syntax becomes sweet like a sugar. 

- [x] Raise proper error when someone tries to reconfigure a registry?! => How to avoid calling the reader before writer?
- [x] Do not allow to define accessors named after existing methods.